### PR TITLE
Remove redundant slot != 0 checks

### DIFF
--- a/src/main/java/io/github/strikerrocker/jukebox/block/ItemHandlerJukebox.java
+++ b/src/main/java/io/github/strikerrocker/jukebox/block/ItemHandlerJukebox.java
@@ -20,12 +20,14 @@ public class ItemHandlerJukebox implements IItemHandlerModifiable {
         this.jukebox = tileEntityJukebox;
     }
 
+    /*
+     Jukebox cannot have a record.
+     ItemStack should not be empty.
+     Used for hoppers and other pushers to push items inside the jukebox.
+      */
     @Override
     public void setStackInSlot(int slot, @Nonnull ItemStack stack) {
-        if (slot != 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        if (jukebox != null && jukebox.getRecord().isEmpty()) {
+        if (jukebox != null && !stack.isEmpty() && jukebox.getRecord().isEmpty()) {
             jukebox.setRecord(stack);
         }
     }
@@ -38,18 +40,12 @@ public class ItemHandlerJukebox implements IItemHandlerModifiable {
     @Nonnull
     @Override
     public ItemStack getStackInSlot(int slot) {
-        if (slot != 0) {
-            throw new IndexOutOfBoundsException();
-        }
         return jukebox.getRecord();
     }
 
     @Nonnull
     @Override
     public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
-        if (slot != 0) {
-            throw new IndexOutOfBoundsException();
-        }
         if (stack.getItem() instanceof RecordItem && getStackInSlot(slot).isEmpty()) {
             if (!simulate) {
                 jukebox.setRecord(stack);
@@ -64,30 +60,23 @@ public class ItemHandlerJukebox implements IItemHandlerModifiable {
     @Nonnull
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
-        if (slot != 0) {
-            throw new IndexOutOfBoundsException();
-        }
-        ItemStack stack = jukebox.getRecord();
         if (!simulate) {
             jukebox.clearContent();
             setPlayState(jukebox, false);
             jukebox.getLevel().levelEvent(1010, jukebox.getBlockPos(), 0);
         }
-        return stack;
+        return jukebox.getRecord();
     }
 
-    private void setPlayState(JukeboxBlockEntity jukebox, boolean b) {
+    private void setPlayState(JukeboxBlockEntity jukebox, boolean flag) {
         BlockState state = jukebox.getLevel().getBlockState(jukebox.getBlockPos());
         if (state.getBlock() instanceof JukeboxBlock) {
-            jukebox.getLevel().setBlock(jukebox.getBlockPos(), state.setValue(JukeboxBlock.HAS_RECORD, b), 1);
+            jukebox.getLevel().setBlock(jukebox.getBlockPos(), state.setValue(JukeboxBlock.HAS_RECORD, flag), 1);
         }
     }
 
     @Override
     public int getSlotLimit(int slot) {
-        if (slot != 0) {
-            throw new IndexOutOfBoundsException();
-        }
         return 1;
     }
 
@@ -95,4 +84,6 @@ public class ItemHandlerJukebox implements IItemHandlerModifiable {
     public boolean isItemValid(int slot, ItemStack stack) {
         return stack.getItem() instanceof RecordItem;
     }
+
+
 }


### PR DESCRIPTION
Throwing outofbounds exception would crash the game. 
the checks are never reached, or should never be reached any way.

fix : return fixed values disregarding slot number. 

bonus : check fix improvement : 
setStackInSlot should only be used by hoppers and other pushers to push items inside, so on top of the slot having to be empty, the given stack should also not be empty (pointless to set an empty slot to empty)

added a bit of flavor comment to setStackInSlot 